### PR TITLE
Fix Hugo git info errors in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,13 @@ RUN if [ -f package.json ]; then \
     npm ci --only=production; \
     fi
 
+# Initialize git repository to avoid git info errors
+RUN git init && \
+    git config user.email "build@docker.local" && \
+    git config user.name "Docker Build" && \
+    git add . && \
+    git commit -m "Initial commit for build"
+
 # Build the site
 RUN hugo --minify --cleanDestinationDir
 


### PR DESCRIPTION
- Initialize git repository in Docker container to satisfy enableGitInfo: true
- Add git config for build process to avoid git-related template errors
- Create minimal git repo without copying full git history
- Resolves 'can't evaluate field WorkingDir' template errors