### PR TITLE
Disable git info in Docker build to fix template errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,8 @@ RUN if [ -f package.json ]; then \
     npm ci --only=production; \
     fi
 
-# Initialize git repository to avoid git info errors
-RUN git init && \
-    git config user.email "build@docker.local" && \
-    git config user.name "Docker Build" && \
-    git add . && \
-    git commit -m "Initial commit for build"
-
-# Build the site
-RUN hugo --minify --cleanDestinationDir
+# Build the site with git info disabled
+RUN hugo --minify --cleanDestinationDir --disableGitInfo
 
 # Stage 2: Serve with nginx
 FROM nginx:alpine


### PR DESCRIPTION
- Use --disableGitInfo flag to bypass git information requirements
- Removes need for git repository initialization in container
- Fixes 'can't evaluate field WorkingDir' template errors
- Cleaner approach than git repo setup